### PR TITLE
option to restrict admin endpoints to just admin users

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,8 +17,13 @@ keycloak.resource=${ACT_KEYCLOAK_RESOURCE:activiti}
 keycloak.ssl-required=${ACT_KEYCLOAK_SSL_REQUIRED:none}
 keycloak.public-client=${ACT_KEYCLOAK_CLIENT:true}
 
+# by default admin endpoints open to every user (role 'user') but role can be overridden to e.g. admin
+admin-role-name=${ACTIVITI_ADMIN_ROLE:user}
+
 keycloak.security-constraints[0].authRoles[0]=${ACT_KEYCLOAK_ROLES:user}
 keycloak.security-constraints[0].securityCollections[0].patterns[0]=${ACT_KEYCLOAK_PATTERNS:/v1/*}
+keycloak.security-constraints[1].authRoles[0]=${admin-role-name}
+keycloak.security-constraints[1].securityCollections[0].patterns[0]=/admin/*
 
 keycloak.principal-attribute=${ACT_KEYCLOAK_PRINCIPAL_ATTRIBUTE:preferred-username}
 # see https://issues.jboss.org/browse/KEYCLOAK-810 for configuration options


### PR DESCRIPTION
offshoot of https://github.com/Activiti/Activiti/issues/1744 - added option in RB for admin user to see all tasks so need option for that to be admin-only