### PR TITLE
try adding font

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #FROM openjdk:11.0-jdk-slim
 FROM adoptopenjdk/openjdk11:jdk-11.0.2.9-slim
 #FROM openjdk:11.0.1-jre-slim-stretch
-#RUN apk --update add fontconfig ttf-dejavu msttcorefonts-installer fontconfig update-ms-fonts fc-cache -f
+RUN apk --update add fontconfig ttf-dejavu msttcorefonts-installer fontconfig update-ms-fonts fc-cache -f
 ENV PORT 8080
 EXPOSE 8080
 COPY target/*.jar /opt/app.jar


### PR DESCRIPTION
Failures in https://github.com/Activiti/activiti-cloud-example-chart/pull/97 (repeatedly failing with `ProcessInstanceTasks.openProcessInstanceDiagram:286 » Feign status 500 reading...
`) might be due to https://github.com/Activiti/example-runtime-bundle/commit/dea5bb414ce1629b043f07aa1cdf240faf714486

If so this may fix it