### PR TITLE
feat: add BPMN timer examples

### DIFF
--- a/src/main/resources/processes/intermediateTimerEventExample.bpmn20.xml
+++ b/src/main/resources/processes/intermediateTimerEventExample.bpmn20.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="intermediateTimerEventExample" name="Timer intermediate event example">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer"/>
+
+        <intermediateCatchEvent id="timer">
+            <timerEventDefinition>
+                <timeDuration>PT1S</timeDuration>
+            </timerEventDefinition>
+        </intermediateCatchEvent>
+
+        <sequenceFlow id="flow2" sourceRef="timer" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+    <bpmndi:BPMNDiagram id="diagram">
+       <bpmndi:BPMNPlane bpmnElement="intermediateTimerEventExample" id="intermediateTimerEventExample_di">
+          <bpmndi:BPMNShape bpmnElement="theStart" id="theStart_di">
+             <omgdc:Bounds height="30.0" width="30.0" x="114.0" y="185.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="timer" id="timer_di">
+             <omgdc:Bounds height="30.0" width="30.0" x="195.0" y="185.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="theEnd" id="theEnd_di">
+             <omgdc:Bounds height="28.0" width="28.0" x="270.0" y="186.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNEdge bpmnElement="flow1" id="flow1_di">
+             <omgdi:waypoint x="144.0" y="200.0"/>
+             <omgdi:waypoint x="195.0" y="200.0"/>
+          </bpmndi:BPMNEdge>
+          <bpmndi:BPMNEdge bpmnElement="flow2" id="flow2_di">
+             <omgdi:waypoint x="225.0" y="200.0"/>
+             <omgdi:waypoint x="270.0" y="200.0"/>
+          </bpmndi:BPMNEdge>
+       </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/src/main/resources/processes/startTimerEventExample.bpmn20.xml
+++ b/src/main/resources/processes/startTimerEventExample.bpmn20.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="startTimerEventExample" name="Timer start event example">
+
+        <startEvent id="theStart">
+            <timerEventDefinition>
+                <timeCycle>R2/PT1S</timeCycle>
+            </timerEventDefinition>
+        </startEvent>    
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="receive"/>
+
+        <userTask id="receive" name="Receive Task"/>
+
+        <sequenceFlow id="flow2" sourceRef="receive" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+    <bpmndi:BPMNDiagram id="diagram">
+       <bpmndi:BPMNPlane bpmnElement="startTimerEventExample" id="startTimerEventExample_di">
+          <bpmndi:BPMNShape bpmnElement="theStart" id="theStart_di">
+             <omgdc:Bounds height="30.0" width="30.0" x="114.0" y="185.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="receive" id="timer_di">
+             <omgdc:Bounds height="30.0" width="30.0" x="195.0" y="185.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="theEnd" id="theEnd_di">
+             <omgdc:Bounds height="28.0" width="28.0" x="270.0" y="186.0"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNEdge bpmnElement="flow1" id="flow1_di">
+             <omgdi:waypoint x="144.0" y="200.0"/>
+             <omgdi:waypoint x="195.0" y="200.0"/>
+          </bpmndi:BPMNEdge>
+          <bpmndi:BPMNEdge bpmnElement="flow2" id="flow2_di">
+             <omgdi:waypoint x="225.0" y="200.0"/>
+             <omgdi:waypoint x="270.0" y="200.0"/>
+          </bpmndi:BPMNEdge>
+       </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+
+</definitions>


### PR DESCRIPTION
This PR adds BPMN timer examples for  intermediary catch and start timer events.

Part of https://github.com/Activiti/Activiti/issues/2636