### PR TITLE
fix(versions): update Activiti/example-runtime-bundle versions

### DIFF
--- a/charts/runtime-bundle/requirements.yaml
+++ b/charts/runtime-bundle/requirements.yaml
@@ -2,4 +2,4 @@
 dependencies:
 - name: "common"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "1.1.25"
+  version: "1.1.26"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `common` to: `1.1.26`