### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.98

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <java.version>11</java.version>
       <maven.compiler.source>${java.version}</maven.compiler.source>
       <maven.compiler.target>${java.version}</maven.compiler.target>
-      <activiti-cloud-dependencies.version>7.1.97</activiti-cloud-dependencies.version>
+      <activiti-cloud-dependencies.version>7.1.98</activiti-cloud-dependencies.version>
       <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
       <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
       <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.98`