### PR TITLE
fix(build): removed duplicated spring-boot.version property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ after_failure:
   - cat **/target/surefire-reports/*.xml | grep -B 1 -A 10 "<error"
   - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 10 "<error"
 
-env:
-  global:
-  - DOCKER_HOST=tcp://127.0.0.1:2375
+# env:
+#   global:
+#   - DOCKER_HOST=tcp://127.0.0.1:2375

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
       <java.version>11</java.version>
       <maven.compiler.source>${java.version}</maven.compiler.source>
       <maven.compiler.target>${java.version}</maven.compiler.target>
-      <activiti-cloud-dependencies.version>7.1.159</activiti-cloud-dependencies.version>
+      <activiti-cloud-dependencies.version>7.1.160</activiti-cloud-dependencies.version>
       <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
       <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
       <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
       <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
       <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
       <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>   
-      <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
       <javax.xml.bind.version>2.3.0</javax.xml.bind.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -98,7 +97,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/activiti-cloud-runtime-bundle-service/pull/395

Fixes https://github.com/Activiti/Activiti/issues/1399