### PR TITLE
fix(versions): update Activiti/example-runtime-bundle versions into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <activiti-cloud-runtime-bundle-service.version>7.1.254</activiti-cloud-runtime-bundle-service.version>
+    <activiti-cloud-runtime-bundle-service.version>7.1.255</activiti-cloud-runtime-bundle-service.version>
     <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.rb:activiti-cloud-runtime-bundle-dependencies` to: `7.1.255`