### PR TITLE
fix(versions): update Activiti/example-runtime-bundle versions into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <properties>
     <activiti-cloud-runtime-bundle-service.version>7.1.259</activiti-cloud-runtime-bundle-service.version>
     <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
-    <activiti-cloud-messages-service.version>7.1.38</activiti-cloud-messages-service.version>
+    <activiti-cloud-messages-service.version>7.1.39</activiti-cloud-messages-service.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.messages:activiti-cloud-messages-dependencies` to: `7.1.39`