### PR TITLE
fix(versions): update Activiti/example-runtime-bundle versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <activiti-cloud-runtime-bundle-service.version>7.1.424</activiti-cloud-runtime-bundle-service.version>
+    <activiti-cloud-runtime-bundle-service.version>7.1.425</activiti-cloud-runtime-bundle-service.version>
     <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
-    <activiti-cloud-messages-service.version>7.1.424</activiti-cloud-messages-service.version>
+    <activiti-cloud-messages-service.version>7.1.425</activiti-cloud-messages-service.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.modeling:activiti-cloud-modeling-dependencies` to: `7.1.425`